### PR TITLE
fix: Add robust type checking for API responses

### DIFF
--- a/R/R/process_anthropic.R
+++ b/R/R/process_anthropic.R
@@ -2,28 +2,28 @@
 #' @keywords internal
 process_anthropic <- function(prompt, model, api_key) {
   write_log(sprintf("Starting Anthropic API request with model: %s", model))
-  
+
   # Anthropic API endpoint
   url <- "https://api.anthropic.com/v1/messages"
   write_log(sprintf("Using model: %s", model))
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   cutnum <- 1  # Changed to always use 1 chunk
-  
+
   write_log(sprintf("Processing %d chunks of input", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("Processing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -35,7 +35,7 @@ process_anthropic <- function(prompt, model, api_key) {
         )
       )
     )
-    
+
     write_log("Sending API request...")
     # Make the API request
     response <- httr::POST(
@@ -48,31 +48,51 @@ process_anthropic <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (!inherits(response, "response")) {
       write_log("ERROR: Invalid response object")
       return(NULL)
     }
-    
+
     if (response$status_code >= 400) {
       error_message <- httr::content(response, "parsed")
-      write_log(sprintf("ERROR: Anthropic API request failed: %s", 
+      write_log(sprintf("ERROR: Anthropic API request failed: %s",
                        if (!is.null(error_message$error$message)) error_message$error$message else "Unknown error"))
       return(NULL)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$content) || length(content$content) == 0 ||
+        is.null(content$content[[1]]$text)) {
+      write_log("ERROR: Unexpected response format from Anthropic API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$content)) {
+        write_log(sprintf("Content structure: %s", jsonlite::toJSON(content$content, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
     # Claude's response is in content$content[[1]]$text
-    res <- strsplit(content$content[[1]]$text, '\n')[[1]]
+    response_content <- content$content[[1]]$text
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$content[[1]], auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from Claude:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_deepseek.R
+++ b/R/R/process_deepseek.R
@@ -2,28 +2,28 @@
 #' @keywords internal
 process_deepseek <- function(prompt, model, api_key) {
   write_log(sprintf("Starting DeepSeek API request with model: %s", model))
-  
+
   # DeepSeek API endpoint
   url <- "https://api.deepseek.com/v1/chat/completions"
   write_log(sprintf("Using model: %s", model))
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   cutnum <- 1  # Changed to always use 1 chunk
-  
+
   write_log(sprintf("Processing %d chunks of input", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("Processing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -39,7 +39,7 @@ process_deepseek <- function(prompt, model, api_key) {
       ),
       stream = FALSE
     )
-    
+
     write_log("Sending API request...")
     # Make the API request
     response <- httr::POST(
@@ -51,25 +51,46 @@ process_deepseek <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (httr::http_error(response)) {
       error_message <- httr::content(response, "parsed")
       write_log(sprintf("ERROR: DeepSeek API request failed: %s", error_message$error$message))
       stop("DeepSeek API request failed: ", error_message$error$message)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
+      write_log("ERROR: Unexpected response format from DeepSeek API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$choices)) {
+        write_log(sprintf("Choices structure: %s", jsonlite::toJSON(content$choices, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
+    # DeepSeek's response should be in content$choices[[1]]$message$content
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
     # DeepSeek's response is in content$choices[[1]]$message$content
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from DeepSeek:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_grok.R
+++ b/R/R/process_grok.R
@@ -8,28 +8,28 @@
 #' @keywords internal
 process_grok <- function(prompt, model, api_key) {
   write_log(sprintf("Starting X.AI Grok API request with model: %s", model))
-  
+
   # X.AI Grok API endpoint
   url <- "https://api.x.ai/v1/chat/completions"
   write_log(sprintf("Using model: %s", model))
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   cutnum <- 1  # Always use 1 chunk for processing
-  
+
   write_log(sprintf("Processing %d chunks of input", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(seq_along(input_lines), cutnum))	
+    cid <- as.numeric(cut(seq_along(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(seq_len(cutnum), function(i) {
     write_log(sprintf("Processing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -42,7 +42,7 @@ process_grok <- function(prompt, model, api_key) {
         )
       )
     )
-    
+
     write_log("Sending API request...")
     # Make the API request
     response <- httr::POST(
@@ -54,24 +54,24 @@ process_grok <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (!inherits(response, "response")) {
       write_log("ERROR: Invalid response object")
       return(NULL)
     }
-    
+
     if (response$status_code >= 400) {
       error_message <- httr::content(response, "parsed")
-      write_log(sprintf("ERROR: X.AI Grok API request failed: %s", 
+      write_log(sprintf("ERROR: X.AI Grok API request failed: %s",
                        if (!is.null(error_message$error$message)) error_message$error$message else "Unknown error"))
       return(NULL)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
-    
+
     # Extract the response text from the Grok API response
     # The standard format is:
     # {
@@ -93,33 +93,41 @@ process_grok <- function(prompt, model, api_key) {
     #   "usage": {...},
     #   "system_fingerprint": "fp_84ff176447"
     # }
-    
+
     # Check if we have a valid response structure
-    if (is.null(content$choices) || length(content$choices) == 0 || 
-        is.null(content$choices[[1]]$message) || 
+    if (is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) ||
         is.null(content$choices[[1]]$message$content)) {
       write_log("ERROR: Unexpected response format from Grok API")
       write_log(sprintf("Raw response: %s", jsonlite::toJSON(content, auto_unbox = TRUE)))
       return(NULL)
     }
-    
+
     # Extract the content from the message
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
-    
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
+    res <- strsplit(response_content, '\n')[[1]]
+
     # Log usage information if available
     if (!is.null(content$usage)) {
-      write_log(sprintf("Tokens used - Prompt: %d, Completion: %d, Total: %d", 
-                      content$usage$prompt_tokens, 
-                      content$usage$completion_tokens, 
+      write_log(sprintf("Tokens used - Prompt: %d, Completion: %d, Total: %d",
+                      content$usage$prompt_tokens,
+                      content$usage$completion_tokens,
                       content$usage$total_tokens))
     }
-    
+
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from Grok:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_openai.R
+++ b/R/R/process_openai.R
@@ -2,34 +2,34 @@
 #' @keywords internal
 process_openai <- function(prompt, model, api_key) {
   write_log(sprintf("Starting OpenAI API request with model: %s", model))
-  
+
   # Check if API key is provided and not empty
   if (is.null(api_key) || api_key == "") {
     write_log("ERROR: OpenAI API key is missing or empty")
     stop("OpenAI API key is required but not provided")
   }
-  
+
   # OpenAI API endpoint
   url <- "https://api.openai.com/v1/chat/completions"
   write_log(sprintf("Using model: %s", model))
-  
+
   # Process all input at once instead of chunks
   input_lines <- strsplit(prompt, "\n")[[1]]
   cutnum <- 1  # Changed to always use 1 chunk
-  
+
   write_log(sprintf("Processing %d chunks of input", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("Processing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -41,7 +41,7 @@ process_openai <- function(prompt, model, api_key) {
       ),
       store = TRUE
     )
-    
+
     write_log("Sending API request...")
     # Make the API request
     response <- httr::POST(
@@ -53,24 +53,45 @@ process_openai <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (httr::http_error(response)) {
       error_message <- httr::content(response, "parsed")
       write_log(sprintf("ERROR: OpenAI API request failed: %s", error_message$error$message))
       stop("OpenAI API request failed: ", error_message$error$message)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
+      write_log("ERROR: Unexpected response format from OpenAI API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$choices)) {
+        write_log(sprintf("Choices structure: %s", jsonlite::toJSON(content$choices, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
+    # OpenAI's response should be in content$choices[[1]]$message$content
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from OpenAI:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_qwen.R
+++ b/R/R/process_qwen.R
@@ -2,12 +2,12 @@
 #' @keywords internal
 process_qwen <- function(prompt, model, api_key) {
   write_log(sprintf("Starting QWEN API request with model: %s", model))
-  
+
   # Determine the appropriate API endpoint based on the key
   # Try international endpoint first, if it fails, try mainland endpoint
   international_endpoint <- "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
   mainland_endpoint <- "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
-  
+
   # Function to detect API key type
   detect_api_endpoint <- function(api_key) {
     # First try with international endpoint
@@ -17,7 +17,7 @@ process_qwen <- function(prompt, model, api_key) {
       max_tokens = 10,
       messages = list(list(role = "user", content = "test"))
     )
-    
+
     test_response <- tryCatch({
       httr::POST(
         url = test_url,
@@ -32,17 +32,17 @@ process_qwen <- function(prompt, model, api_key) {
       write_log(sprintf("Error testing international endpoint: %s", e$message))
       return(NULL)
     })
-    
+
     # Check if international endpoint works
     if (!is.null(test_response) && !httr::http_error(test_response)) {
       write_log("International API endpoint detected and working")
       return(international_endpoint)
     }
-    
+
     # If international fails, try mainland endpoint
     write_log("International endpoint failed, trying mainland endpoint")
     test_url <- mainland_endpoint
-    
+
     test_response <- tryCatch({
       httr::POST(
         url = test_url,
@@ -57,40 +57,40 @@ process_qwen <- function(prompt, model, api_key) {
       write_log(sprintf("Error testing mainland endpoint: %s", e$message))
       return(NULL)
     })
-    
+
     # Check if mainland endpoint works
     if (!is.null(test_response) && !httr::http_error(test_response)) {
       write_log("Mainland API endpoint detected and working")
       return(mainland_endpoint)
     }
-    
+
     # If both fail, default to international endpoint and let the main function handle the error
     write_log("Both endpoints failed, defaulting to international endpoint")
     return(international_endpoint)
   }
-  
+
   # Detect and use the appropriate endpoint
   url <- detect_api_endpoint(api_key)
   write_log(sprintf("Using endpoint: %s", url))
   write_log(sprintf("Using model: %s", model))
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   cutnum <- 1  # Changed to always use 1 chunk
-  
+
   write_log(sprintf("Processing %d chunks of input", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("Processing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -102,7 +102,7 @@ process_qwen <- function(prompt, model, api_key) {
         )
       )
     )
-    
+
     write_log("Sending API request...")
     # Make the API request
     response <- httr::POST(
@@ -114,24 +114,45 @@ process_qwen <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (httr::http_error(response)) {
       error_message <- httr::content(response, "parsed")
       write_log(sprintf("ERROR: QWEN API request failed: %s", error_message$error$message))
       stop("QWEN API request failed: ", error_message$error$message)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
+      write_log("ERROR: Unexpected response format from QWEN API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$choices)) {
+        write_log(sprintf("Choices structure: %s", jsonlite::toJSON(content$choices, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
+    # QWEN's response should be in content$choices[[1]]$message$content
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from QWEN:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_stepfun.R
+++ b/R/R/process_stepfun.R
@@ -3,35 +3,35 @@
 process_stepfun <- function(prompt, model, api_key) {
   write_log("\n=== Starting Stepfun API Request ===\n")
   write_log(sprintf("Model: %s", model))
-  
+
   # Stepfun API endpoint
   url <- "https://api.stepfun.com/v1/chat/completions"
   write_log("API URL:")
   write_log(url)
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   write_log("\nInput lines:")
   write_log(paste(input_lines, collapse = "\n"))
-  
+
   cutnum <- 1  # Changed to always use 1 chunk
   write_log(sprintf("\nProcessing input in %d chunk(s)", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("\nProcessing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     chunk_content <- paste(input_lines[id], collapse = '\n')
     write_log("\nChunk content:")
     write_log(chunk_content)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -42,10 +42,10 @@ process_stepfun <- function(prompt, model, api_key) {
         )
       )
     )
-    
+
     write_log("\nRequest body:")
     write_log(jsonlite::toJSON(body, auto_unbox = TRUE, pretty = TRUE))
-    
+
     write_log("\nSending API request...")
     # Make the API request
     response <- httr::POST(
@@ -57,26 +57,47 @@ process_stepfun <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (httr::http_error(response)) {
       error_message <- httr::content(response, "parsed")
-      write_log(sprintf("ERROR: Stepfun API request failed: %s", 
+      write_log(sprintf("ERROR: Stepfun API request failed: %s",
                        if (!is.null(error_message$error$message)) error_message$error$message else "Unknown error"))
       return(NULL)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
+      write_log("ERROR: Unexpected response format from Stepfun API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$choices)) {
+        write_log(sprintf("Choices structure: %s", jsonlite::toJSON(content$choices, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
+    # Stepfun's response should be in content$choices[[1]]$message$content
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
     # Stepfun's response is in content$choices[[1]]$message$content
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from Stepfun:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }

--- a/R/R/process_zhipu.R
+++ b/R/R/process_zhipu.R
@@ -3,35 +3,35 @@
 process_zhipu <- function(prompt, model, api_key) {
   write_log("\n=== Starting Zhipu AI API Request ===\n")
   write_log(sprintf("Model: %s", model))
-  
+
   # Zhipu AI API endpoint
   url <- "https://open.bigmodel.cn/api/paas/v4/chat/completions"
   write_log("API URL:")
   write_log(url)
-  
+
   # Process all input at once
   input_lines <- strsplit(prompt, "\n")[[1]]
   write_log("\nInput lines:")
   write_log(paste(input_lines, collapse = "\n"))
-  
+
   cutnum <- 1  # Changed to always use 1 chunk
   write_log(sprintf("\nProcessing input in %d chunk(s)", cutnum))
-  
+
   if (cutnum > 1) {
-    cid <- as.numeric(cut(1:length(input_lines), cutnum))	
+    cid <- as.numeric(cut(1:length(input_lines), cutnum))
   } else {
     cid <- rep(1, length(input_lines))
   }
-  
+
   # Process each chunk
   allres <- sapply(1:cutnum, function(i) {
     write_log(sprintf("\nProcessing chunk %d of %d", i, cutnum))
     id <- which(cid == i)
-    
+
     chunk_content <- paste(input_lines[id], collapse = '\n')
     write_log("\nChunk content:")
     write_log(chunk_content)
-    
+
     # Prepare the request body
     body <- list(
       model = model,
@@ -42,10 +42,10 @@ process_zhipu <- function(prompt, model, api_key) {
         )
       )
     )
-    
+
     write_log("\nRequest body:")
     write_log(jsonlite::toJSON(body, auto_unbox = TRUE, pretty = TRUE))
-    
+
     write_log("\nSending API request...")
     # Make the API request
     response <- httr::POST(
@@ -57,26 +57,47 @@ process_zhipu <- function(prompt, model, api_key) {
       body = jsonlite::toJSON(body, auto_unbox = TRUE),
       encode = "json"
     )
-    
+
     # Check for errors
     if (httr::http_error(response)) {
       error_message <- httr::content(response, "parsed")
-      write_log(sprintf("ERROR: Zhipu AI API request failed: %s", 
+      write_log(sprintf("ERROR: Zhipu AI API request failed: %s",
                        if (!is.null(error_message$error$message)) error_message$error$message else "Unknown error"))
       return(NULL)
     }
-    
+
     write_log("Parsing API response...")
     # Parse the response
     content <- httr::content(response, "parsed")
+
+    # Check if response has the expected structure
+    if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
+        is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
+      write_log("ERROR: Unexpected response format from Zhipu API")
+      write_log(sprintf("Content structure: %s", paste(names(content), collapse = ", ")))
+      if (!is.null(content$choices)) {
+        write_log(sprintf("Choices structure: %s", jsonlite::toJSON(content$choices, auto_unbox = TRUE, pretty = TRUE)))
+      }
+      return(NULL)
+    }
+
     # Zhipu's response should be in content$choices[[1]]$message$content
-    res <- strsplit(content$choices[[1]]$message$content, '\n')[[1]]
+    response_content <- content$choices[[1]]$message$content
+    if (!is.character(response_content)) {
+      write_log("ERROR: Response content is not a character string")
+      write_log(sprintf("Response content type: %s", typeof(response_content)))
+      write_log(sprintf("Response content structure: %s", jsonlite::toJSON(content$choices[[1]]$message, auto_unbox = TRUE, pretty = TRUE)))
+      return(NULL)
+    }
+
+    # Process the response
+    res <- strsplit(response_content, '\n')[[1]]
     write_log(sprintf("Got response with %d lines", length(res)))
     write_log(sprintf("Raw response from Zhipu:\n%s", paste(res, collapse = "\n")))
-    
+
     res
   }, simplify = FALSE)
-  
+
   write_log("All chunks processed successfully")
   return(gsub(',$', '', unlist(allres)))
 }


### PR DESCRIPTION
This commit adds comprehensive type checking for API responses across all model providers:

- Add validation to ensure response content has the expected structure
- Add explicit checks to verify that response content is a character string before using strsplit
- Add detailed error logging for unexpected response formats
- Gracefully handle non-character responses by returning NULL instead of crashing
- Implement consistent error handling patterns across all API processing functions

This fixes the 'non-character argument' error that occurred when strsplit was called on non-character response content, which could happen due to API format changes, streaming responses, rate limiting, or network issues.

The changes make the code more robust against various API response scenarios and provide better diagnostic information when errors occur.