### PR TITLE
feat(consensus): thread prompt_template through interactive_consensus_annotation

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Python implementation of mLLMCelltype will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- `interactive_consensus_annotation` now accepts an optional `prompt_template`
+  argument, forwarded to the initial annotation phase (`create_prompt`). This
+  exposes the existing per-prompt customization of `annotate_clusters` through
+  the consensus entry point, enabling custom task framing / output contracts
+  (e.g. functional-state annotation) without monkeypatching
+  `DEFAULT_PROMPT_TEMPLATE`. Defaults to `None`, preserving current behavior.
+
 ## [2.0.5] - 2026-05-11
 
 ### Fixed

--- a/python/mllmcelltype/consensus.py
+++ b/python/mllmcelltype/consensus.py
@@ -2135,12 +2135,12 @@ def _run_initial_annotations(
     api_keys: dict[str, str],
     tissue: str | None,
     additional_context: str | None,
-    prompt_template: str | None,
     use_cache: bool,
     force_rerun: bool,
     cache_dir: str | None,
     base_urls: str | dict[str, str] | None,
     verbose: bool,
+    prompt_template: str | None = None,
 ) -> dict[str, dict[str, str]]:
     """Run initial annotation phase across models with de-dup and error isolation."""
     model_results: dict[str, dict[str, str]] = {}
@@ -2345,7 +2345,6 @@ def interactive_consensus_annotation(
     api_keys: dict[str, str] | None = None,
     tissue: str | None = None,
     additional_context: str | None = None,
-    prompt_template: str | None = None,
     consensus_threshold: float = 0.7,
     entropy_threshold: float = 1.0,
     max_discussion_rounds: int = 3,
@@ -2356,6 +2355,7 @@ def interactive_consensus_annotation(
     base_urls: str | dict[str, str] | None = None,
     clusters_to_analyze: list[str] | None = None,
     force_rerun: bool = False,
+    prompt_template: str | None = None,
 ) -> dict[str, Any]:
     """Perform consensus annotation of cell types using multiple LLMs and interactive resolution.
 
@@ -2366,10 +2366,6 @@ def interactive_consensus_annotation(
         api_keys: Dictionary mapping provider names to API keys
         tissue: Optional tissue name (e.g., 'brain', 'liver')
         additional_context: Additional context to include in the prompt
-        prompt_template: Optional custom prompt template for the initial annotation
-            phase. Supports the ``{species}``, ``{tissue}`` and ``{markers}``
-            placeholders. If None (default), the built-in
-            ``DEFAULT_PROMPT_TEMPLATE`` is used.
         consensus_threshold: Agreement threshold below which a cluster is considered controversial
         entropy_threshold: Entropy threshold above which a cluster is considered controversial
         max_discussion_rounds: Maximum number of discussion rounds for controversial clusters
@@ -2391,6 +2387,11 @@ def interactive_consensus_annotation(
             discussion phase for controversial clusters. Useful when you want to
             re-analyze clusters with different context or for subtype identification.
             Default is False. Only effective when use_cache is True.
+        prompt_template: Optional custom prompt template for the initial annotation
+            phase. Supports the ``{species}``, ``{tissue}`` and ``{markers}``
+            placeholders. If None (default), the built-in
+            ``DEFAULT_PROMPT_TEMPLATE`` is used. Placed at the end of the
+            signature to preserve compatibility with existing positional calls.
 
     Returns:
         dict[str, Any]: Dictionary containing consensus results and metadata

--- a/python/mllmcelltype/consensus.py
+++ b/python/mllmcelltype/consensus.py
@@ -2135,6 +2135,7 @@ def _run_initial_annotations(
     api_keys: dict[str, str],
     tissue: str | None,
     additional_context: str | None,
+    prompt_template: str | None,
     use_cache: bool,
     force_rerun: bool,
     cache_dir: str | None,
@@ -2180,6 +2181,7 @@ def _run_initial_annotations(
                 api_key=api_key,
                 tissue=tissue,
                 additional_context=additional_context,
+                prompt_template=prompt_template,
                 use_cache=use_cache and not force_rerun,
                 cache_dir=cache_dir,
                 base_urls=base_urls,
@@ -2343,6 +2345,7 @@ def interactive_consensus_annotation(
     api_keys: dict[str, str] | None = None,
     tissue: str | None = None,
     additional_context: str | None = None,
+    prompt_template: str | None = None,
     consensus_threshold: float = 0.7,
     entropy_threshold: float = 1.0,
     max_discussion_rounds: int = 3,
@@ -2363,6 +2366,10 @@ def interactive_consensus_annotation(
         api_keys: Dictionary mapping provider names to API keys
         tissue: Optional tissue name (e.g., 'brain', 'liver')
         additional_context: Additional context to include in the prompt
+        prompt_template: Optional custom prompt template for the initial annotation
+            phase. Supports the ``{species}``, ``{tissue}`` and ``{markers}``
+            placeholders. If None (default), the built-in
+            ``DEFAULT_PROMPT_TEMPLATE`` is used.
         consensus_threshold: Agreement threshold below which a cluster is considered controversial
         entropy_threshold: Entropy threshold above which a cluster is considered controversial
         max_discussion_rounds: Maximum number of discussion rounds for controversial clusters
@@ -2412,6 +2419,7 @@ def interactive_consensus_annotation(
         api_keys=api_keys,
         tissue=tissue,
         additional_context=additional_context,
+        prompt_template=prompt_template,
         use_cache=use_cache,
         force_rerun=force_rerun,
         cache_dir=cache_dir,

--- a/python/tests/test_consensus.py
+++ b/python/tests/test_consensus.py
@@ -170,6 +170,43 @@ class TestConsensus:
         # A stable phrase from DEFAULT_PROMPT_TEMPLATE.
         assert "IN NUMERICAL ORDER" in prompts[0]
 
+    @patch("mllmcelltype.consensus.check_consensus")
+    @patch("mllmcelltype.consensus.annotate_clusters")
+    def test_interactive_consensus_annotation_preserves_legacy_positional_thresholds(
+        self,
+        mock_annotate_clusters,
+        mock_check_consensus,
+    ):
+        """Adding prompt_template must not shift existing positional arguments."""
+        mock_annotate_clusters.return_value = {"1": "T cells"}
+        mock_check_consensus.return_value = (
+            {"1": "T cells"},
+            {"1": 1.0},
+            {"1": 0.0},
+            [],
+        )
+
+        result = interactive_consensus_annotation(
+            {"1": ["CD3D"]},
+            "human",
+            [{"provider": "openai", "model": "gpt-4o"}],
+            {"openai": "test-key"},
+            "blood",
+            None,
+            0.8,
+            1.2,
+            0,
+            False,
+        )
+
+        assert result["consensus"]["1"] == "T cells"
+        annotate_kwargs = mock_annotate_clusters.call_args.kwargs
+        assert annotate_kwargs["prompt_template"] is None
+        assert annotate_kwargs["use_cache"] is False
+        check_kwargs = mock_check_consensus.call_args.kwargs
+        assert check_kwargs["consensus_threshold"] == 0.8
+        assert check_kwargs["entropy_threshold"] == 1.2
+
     def test_normalize_api_keys_strips_and_drops_blank(self):
         """Test api key normalization trims and removes blank entries."""
         normalized = _normalize_api_keys(

--- a/python/tests/test_consensus.py
+++ b/python/tests/test_consensus.py
@@ -21,6 +21,7 @@ from mllmcelltype.consensus import (
     _merge_consensus_and_resolved,
     _normalize_api_keys,
     _normalize_consensus_model_spec,
+    _run_initial_annotations,
     check_consensus,
     check_consensus_for_discussion_round,
     interactive_consensus_annotation,
@@ -115,6 +116,59 @@ class TestConsensus:
         assert merged["2"] == "Unknown"
         assert merged["3"] == "Unknown"
         assert merged["4"] == "B cells"
+
+    @staticmethod
+    def _capture_initial_prompts(prompt_template):
+        """Run the initial-annotation phase with the network stubbed; return prompts sent.
+
+        Patches the provider registry (not the annotation function), so the real
+        ``create_prompt`` runs and we observe the actual outgoing prompt text.
+        """
+        captured: list[str] = []
+
+        def fake_provider_func(prompt, model, api_key, base_url):
+            captured.append(prompt)
+            return ["Cluster 1: T cells"]
+
+        with patch.dict(
+            "mllmcelltype.annotate.PROVIDER_FUNCTIONS",
+            {"openai": fake_provider_func},
+        ):
+            _run_initial_annotations(
+                marker_genes={"1": ["CD3D", "CD3E"]},
+                species="human",
+                models=[{"provider": "openai", "model": "gpt-4o"}],
+                api_keys={"openai": "sk-test"},
+                tissue="blood",
+                additional_context=None,
+                prompt_template=prompt_template,
+                use_cache=False,
+                force_rerun=False,
+                cache_dir=None,
+                base_urls=None,
+                verbose=False,
+            )
+        return captured
+
+    def test_custom_prompt_template_reaches_outgoing_prompt(self):
+        """A custom prompt_template's text actually lands in the prompt sent to the model."""
+        sentinel = "QQQ_CUSTOM_STATE_TASK_QQQ"
+        custom_template = f"{sentinel}\nSpecies {{species}}, tissue {{tissue}}.\n{{markers}}"
+
+        prompts = self._capture_initial_prompts(custom_template)
+
+        assert prompts, "provider was never called"
+        assert sentinel in prompts[0]
+        # The default template's instruction must NOT survive a full override.
+        assert "IN NUMERICAL ORDER" not in prompts[0]
+
+    def test_default_prompt_template_used_when_none(self):
+        """With prompt_template=None the built-in default template is used (no regression)."""
+        prompts = self._capture_initial_prompts(None)
+
+        assert prompts, "provider was never called"
+        # A stable phrase from DEFAULT_PROMPT_TEMPLATE.
+        assert "IN NUMERICAL ORDER" in prompts[0]
 
     def test_normalize_api_keys_strips_and_drops_blank(self):
         """Test api key normalization trims and removes blank entries."""


### PR DESCRIPTION
## Why

I ran into this building a multi-model consensus annotator on top of `interactive_consensus_annotation`. I wanted to reuse the consensus machinery for **cell-state** calls — different task framing and output contract (functional states, not cell-type labels), which means swapping the prompt.

Problem: there's no way to. `create_prompt` and `annotate_clusters` already take a `prompt_template`, but the consensus entry point neither accepts nor forwards one, so the initial phase is hard-wired to `DEFAULT_PROMPT_TEMPLATE`. The only workaround was monkeypatching the module global at runtime — fragile, and pinned to an exact version.

This just plumbs through the parameter that already exists one layer down.

## What

- `interactive_consensus_annotation` gains an optional `prompt_template` (default `None`), forwarded via `_run_initial_annotations` → `annotate_clusters`.
- Two behavioral tests: a custom template's text actually reaches the outgoing prompt; `None` still selects the default (provider stubbed, real `create_prompt` runs).
- CHANGELOG note under `[Unreleased]`.

When omitted, the prompt is byte-for-byte what it is today. Discussion prompts are untouched, and the cache key already derives from prompt text, so a new template gets its own cache entry.

## Tested

`pytest tests/` → 320 passed, 1 skipped (integration); `ruff check` clean. Checked the tests actually bite: drop the forwarding and the custom-template test fails (prompt falls back to default) while the default-template test stays green.
