### PR TITLE
[codex] align provider API endpoint contracts

### DIFF
--- a/R/R/anthropic_processor.R
+++ b/R/R/anthropic_processor.R
@@ -57,26 +57,7 @@ AnthropicProcessor <- R6::R6Class("AnthropicProcessor",
         encode = "json"
       )
       
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-
-        self$logger$error("Anthropic API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-
-        stop(sprintf("Anthropic API request failed: %s", error_message))
-      }
+      private$stop_for_http_error(response, model, "Anthropic")
       
       return(response)
     },

--- a/R/R/api_utils.R
+++ b/R/R/api_utils.R
@@ -14,20 +14,38 @@
 #' @export
 get_api_key <- function(model, api_keys) {
   provider <- get_provider(model)
+  model_normalized <- trimws(model)
   is_valid_key <- function(key) {
     is.character(key) && length(key) == 1 && !is.na(key) && nzchar(trimws(key))
   }
+  get_named_key <- function(key_name) {
+    api_key_names <- names(api_keys)
+    if (is.null(api_key_names)) {
+      return(NULL)
+    }
+
+    match_idx <- match(tolower(trimws(key_name)), tolower(trimws(api_key_names)))
+    if (is.na(match_idx)) {
+      return(NULL)
+    }
+
+    key <- api_keys[[match_idx]]
+    if (is_valid_key(key)) {
+      return(trimws(key))
+    }
+    NULL
+  }
 
   # First try to get by provider name
-  if (provider %in% names(api_keys)) {
-    key <- api_keys[[provider]]
-    if (is_valid_key(key)) return(trimws(key))
+  key <- get_named_key(provider)
+  if (!is.null(key)) {
+    return(key)
   }
 
   # If not found, try to get by model name
-  if (model %in% names(api_keys)) {
-    key <- api_keys[[model]]
-    if (is_valid_key(key)) return(trimws(key))
+  key <- get_named_key(model_normalized)
+  if (!is.null(key)) {
+    return(key)
   }
 
   # If still not found or all keys empty, return NULL

--- a/R/R/base_api_processor.R
+++ b/R/R/base_api_processor.R
@@ -37,13 +37,15 @@ BaseAPIProcessor <- R6::R6Class("BaseAPIProcessor",
     #
     process_request = function(prompt, model, api_key) {
       start_time <- Sys.time()
-      
-      self$logger$info(sprintf("Starting %s API request", self$provider_name), 
-                      list(model = model, provider = self$provider_name))
-      
+
       tryCatch({
         # Validate inputs
         private$validate_inputs(prompt, model, api_key)
+        model <- trimws(as.character(model))
+        api_key <- trimws(as.character(api_key))
+
+        self$logger$info(sprintf("Starting %s API request", self$provider_name),
+                        list(model = model, provider = self$provider_name))
 
         # Make the API call and extract response
         final_result <- private$call_and_extract(prompt, model, api_key)
@@ -140,7 +142,7 @@ BaseAPIProcessor <- R6::R6Class("BaseAPIProcessor",
       }
       
       self$logger$debug("Input validation passed",
-                       list(provider = self$provider_name, model = model))
+                       list(provider = self$provider_name, model = trimws(as.character(model))))
     },
     
     #' Make API call and extract response content
@@ -209,6 +211,154 @@ BaseAPIProcessor <- R6::R6Class("BaseAPIProcessor",
                             lines_count = length(res),
                             response_length = nchar(content)))
       return(res)
+    },
+
+    provider_display_name = function() {
+      provider_names <- list(
+        openai = "OpenAI",
+        anthropic = "Anthropic",
+        deepseek = "DeepSeek",
+        gemini = "Gemini",
+        qwen = "Qwen",
+        stepfun = "StepFun",
+        zhipu = "Zhipu",
+        minimax = "MiniMax",
+        grok = "Grok",
+        openrouter = "OpenRouter"
+      )
+      provider_label <- provider_names[[self$provider_name]]
+      if (is.null(provider_label)) {
+        return(self$provider_name)
+      }
+      provider_label
+    },
+
+    build_chat_completions_body = function(chunk_content, model, extra = list()) {
+      body <- list(
+        model = model,
+        messages = list(
+          list(
+            role = "user",
+            content = chunk_content
+          )
+        )
+      )
+
+      if (length(extra) > 0) {
+        for (field in names(extra)) {
+          body[[field]] <- extra[[field]]
+        }
+      }
+
+      body
+    },
+
+    extract_error_message = function(response) {
+      error_content <- tryCatch(
+        httr::content(response, "parsed"),
+        error = function(e) NULL
+      )
+      is_non_empty_string <- function(value) {
+        is.character(value) && length(value) == 1 && !is.na(value) && nzchar(value)
+      }
+
+      if (is.list(error_content) &&
+          is.list(error_content$error) &&
+          is_non_empty_string(error_content$error$message)) {
+        return(error_content$error$message)
+      }
+      if (is.list(error_content) &&
+          is_non_empty_string(error_content$error)) {
+        return(error_content$error)
+      }
+      if (is.list(error_content) &&
+          is_non_empty_string(error_content$message)) {
+        return(error_content$message)
+      }
+
+      sprintf("HTTP %d error", httr::status_code(response))
+    },
+
+    stop_for_http_error = function(response, model, provider_label = private$provider_display_name()) {
+      if (!httr::http_error(response)) {
+        return(invisible(NULL))
+      }
+
+      error_message <- private$extract_error_message(response)
+
+      self$logger$error(sprintf("%s API request failed", provider_label),
+                       list(error = error_message,
+                            provider = self$provider_name,
+                            model = model,
+                            status_code = httr::status_code(response)))
+
+      stop(sprintf("%s API request failed: %s", provider_label, error_message))
+    },
+
+    post_chat_completions_request = function(chunk_content,
+                                            model,
+                                            api_key,
+                                            api_url = self$get_api_url(),
+                                            body_extra = list(),
+                                            headers = list(),
+                                            provider_label = private$provider_display_name()) {
+      body <- private$build_chat_completions_body(
+        chunk_content = chunk_content,
+        model = model,
+        extra = body_extra
+      )
+
+      self$logger$debug(sprintf("Sending API request to %s", provider_label),
+                       list(model = model, provider = self$provider_name))
+
+      request_headers <- c(
+        list(
+          "Authorization" = paste("Bearer", api_key),
+          "Content-Type" = "application/json"
+        ),
+        headers
+      )
+
+      response <- httr::POST(
+        url = api_url,
+        do.call(httr::add_headers, request_headers),
+        body = jsonlite::toJSON(body, auto_unbox = TRUE),
+        encode = "json"
+      )
+
+      private$stop_for_http_error(response, model, provider_label)
+      response
+    },
+
+    extract_chat_completions_content = function(response,
+                                               model,
+                                               provider_label = private$provider_display_name()) {
+      self$logger$debug(sprintf("Parsing %s API response", provider_label),
+                       list(provider = self$provider_name, model = model))
+
+      content <- httr::content(response, "parsed")
+
+      if (is.null(content) ||
+          is.null(content$choices) ||
+          length(content$choices) == 0 ||
+          is.null(content$choices[[1]]$message) ||
+          is.null(content$choices[[1]]$message$content)) {
+
+        self$logger$error(sprintf("Unexpected response format from %s API", provider_label),
+                         list(provider = self$provider_name,
+                              model = model,
+                              content_structure = names(content),
+                              choices_available = !is.null(content$choices),
+                              choices_count = if (!is.null(content$choices)) {
+                                length(content$choices)
+                              } else {
+                                0
+                              }))
+
+        stop(sprintf("Unexpected response format from %s API", provider_label))
+      }
+
+      content$choices[[1]]$message$content
     },
 
     is_successful_result = function(result) {

--- a/R/R/cell_type_annotation.R
+++ b/R/R/cell_type_annotation.R
@@ -199,6 +199,10 @@ annotate_cell_types <- function(input,
   if (is.null(tissue_name) || !nzchar(trimws(tissue_name))) {
     stop("tissue_name is required. Specify the tissue type (e.g., 'human PBMC', 'mouse brain').")
   }
+  if (!is.character(model) || length(model) != 1 || is.na(model) || !nzchar(trimws(model))) {
+    stop("model must be a non-empty character scalar")
+  }
+  model <- trimws(model)
 
   # Determine provider from model name
   provider <- get_provider(model)
@@ -248,6 +252,7 @@ annotate_cell_types <- function(input,
   if (api_key_missing) {
     stop("api_key must be a non-empty character scalar, or NA to return prompt only")
   }
+  api_key <- trimws(as.character(api_key))
 
   # Delegate to get_model_response which handles provider dispatch
   result <- get_model_response(prompt, model, api_key, base_urls)

--- a/R/R/deepseek_processor.R
+++ b/R/R/deepseek_processor.R
@@ -30,54 +30,16 @@ DeepSeekProcessor <- R6::R6Class("DeepSeekProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
-        ),
-        stream = FALSE
-      )
-      
-      self$logger$debug("Sending API request to DeepSeek",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Content-Type" = "application/json",
-          "Authorization" = paste("Bearer", api_key)
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
+      private$post_chat_completions_request(
+        chunk_content,
+        model,
+        api_key,
+        body_extra = list(
+          temperature = 0.7,
+          max_tokens = 4096,
+          stream = FALSE
         )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("DeepSeek API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("DeepSeek API request failed: %s", error_message))
-      }
-      
-      return(response)
+      )
     },
     
     #' @description
@@ -86,30 +48,7 @@ DeepSeekProcessor <- R6::R6Class("DeepSeekProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing DeepSeek API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from DeepSeek API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from DeepSeek API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/R/gemini_processor.R
+++ b/R/R/gemini_processor.R
@@ -68,26 +68,7 @@ GeminiProcessor <- R6::R6Class("GeminiProcessor",
         encode = "json"
       )
       
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("Gemini API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("Gemini API request failed: %s", error_message))
-      }
+      private$stop_for_http_error(response, model, "Gemini")
       
       return(response)
     },

--- a/R/R/get_model_response.R
+++ b/R/R/get_model_response.R
@@ -1,6 +1,16 @@
 #' Get response from a specific model
 #' @keywords internal
 get_model_response <- function(prompt, model, api_key, base_urls = NULL) {
+  if (!is.character(model) || length(model) != 1 || is.na(model) || !nzchar(trimws(model))) {
+    stop("model must be a non-empty character scalar")
+  }
+  if (!is.character(api_key) || length(api_key) != 1 || is.na(api_key) || !nzchar(trimws(api_key))) {
+    stop("api_key must be a non-empty character scalar")
+  }
+
+  model <- trimws(model)
+  api_key <- trimws(api_key)
+
   # Get the provider for the model
   provider <- get_provider(model)
 

--- a/R/R/get_provider.R
+++ b/R/R/get_provider.R
@@ -27,7 +27,8 @@ get_provider <- function(model) {
   }
 
   # Normalize model name to lowercase for case-insensitive matching
-  model_lower <- tolower(model)
+  model_normalized <- trimws(model)
+  model_lower <- tolower(model_normalized)
 
   # OpenRouter models always contain '/' (e.g., 'openai/gpt-5.5')
   if (grepl("/", model_lower)) {
@@ -68,7 +69,7 @@ get_provider <- function(model) {
     collapse = "\n"
   )
   stop(
-    "Cannot determine provider for model: '", model, "'\n",
+    "Cannot determine provider for model: '", model_normalized, "'\n",
     "Supported model name patterns:\n", supported, "\n",
     "  openrouter: any model containing '/'\n",
     "Tip: Check for typos in the model name."

--- a/R/R/grok_processor.R
+++ b/R/R/grok_processor.R
@@ -30,53 +30,7 @@ GrokProcessor <- R6::R6Class("GrokProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
-        )
-      )
-      
-      self$logger$debug("Sending API request to Grok",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("Grok API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("Grok API request failed: %s", error_message))
-      }
-      
-      return(response)
+      private$post_chat_completions_request(chunk_content, model, api_key)
     },
     
     #' @description
@@ -85,30 +39,7 @@ GrokProcessor <- R6::R6Class("GrokProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing Grok API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from Grok API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from Grok API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/R/minimax_processor.R
+++ b/R/R/minimax_processor.R
@@ -17,10 +17,10 @@ MinimaxProcessor <- R6::R6Class("MinimaxProcessor",
     },
 
     #' @description
-    #' Get default Minimax API URL
+    #' Get default MiniMax OpenAI-compatible chat completions API URL
     #
     get_default_api_url = function() {
-      return("https://api.minimax.chat/v1/text/chatcompletion_v2")
+      return("https://api.minimax.io/v1/chat/completions")
     },
     
     #' @description
@@ -30,53 +30,7 @@ MinimaxProcessor <- R6::R6Class("MinimaxProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
-        )
-      )
-      
-      self$logger$debug("Sending API request to Minimax",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("Minimax API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("Minimax API request failed: %s", error_message))
-      }
-      
-      return(response)
+      private$post_chat_completions_request(chunk_content, model, api_key)
     },
     
     #' @description
@@ -85,30 +39,62 @@ MinimaxProcessor <- R6::R6Class("MinimaxProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing Minimax API response",
+      self$logger$debug("Parsing MiniMax API response",
                        list(provider = self$provider_name, model = model))
       
       # Parse the response
       content <- httr::content(response, "parsed")
       
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$messages) || length(content$choices[[1]]$messages) == 0 ||
-          is.null(content$choices[[1]]$messages[[1]]$text)) {
+      base_resp <- content$base_resp
+      if (is.list(base_resp) &&
+          !is.null(base_resp$status_code) &&
+          !identical(as.integer(base_resp$status_code), 0L)) {
+        status_msg_available <- is.character(base_resp$status_msg) &&
+          length(base_resp$status_msg) == 1 &&
+          !is.na(base_resp$status_msg) &&
+          nzchar(base_resp$status_msg)
+        error_message <- if (status_msg_available) {
+          base_resp$status_msg
+        } else {
+          "Unknown MiniMax API error"
+        }
+        stop(sprintf("MiniMax API error: %s", error_message))
+      }
+
+      if (!is.null(content$choices) &&
+          length(content$choices) > 0 &&
+          !is.null(content$choices[[1]]$message$content)) {
+        response_content <- content$choices[[1]]$message$content
+      } else if (!is.null(content$choices) &&
+                 length(content$choices) > 0 &&
+                 !is.null(content$choices[[1]]$messages) &&
+                 length(content$choices[[1]]$messages) > 0 &&
+                 !is.null(content$choices[[1]]$messages[[1]]$text)) {
+        # Legacy MiniMax text/chatcompletion_v2 shape.
+        response_content <- content$choices[[1]]$messages[[1]]$text
+      } else {
         
-        self$logger$error("Unexpected response format from Minimax API",
+        self$logger$error("Unexpected response format from MiniMax API",
                          list(provider = self$provider_name,
                               model = model,
                               content_structure = names(content),
                               choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
+                              choices_count = if (!is.null(content$choices)) {
+                                length(content$choices)
+                              } else {
+                                0
+                              }))
         
-        stop("Unexpected response format from Minimax API")
+        stop("Unexpected response format from MiniMax API")
       }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$messages[[1]]$text
-      
+
+      response_content <- gsub(
+        "<think>[\\s\\S]*?</think>\\s*",
+        "",
+        response_content,
+        perl = TRUE
+      )
+
       return(response_content)
     }
   )

--- a/R/R/openai_processor.R
+++ b/R/R/openai_processor.R
@@ -30,53 +30,7 @@ OpenAIProcessor <- R6::R6Class("OpenAIProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
-        )
-      )
-      
-      self$logger$debug("Sending API request to OpenAI",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Content-Type" = "application/json",
-          "Authorization" = paste("Bearer", api_key)
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("OpenAI API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("OpenAI API request failed: %s", error_message))
-      }
-      
-      return(response)
+      private$post_chat_completions_request(chunk_content, model, api_key)
     },
     
     #' @description
@@ -85,30 +39,7 @@ OpenAIProcessor <- R6::R6Class("OpenAIProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing OpenAI API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from OpenAI API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from OpenAI API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/R/openrouter_processor.R
+++ b/R/R/openrouter_processor.R
@@ -30,53 +30,7 @@ OpenRouterProcessor <- R6::R6Class("OpenRouterProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
-        )
-      )
-      
-      self$logger$debug("Sending API request to OpenRouter",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("OpenRouter API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("OpenRouter API request failed: %s", error_message))
-      }
-      
-      return(response)
+      private$post_chat_completions_request(chunk_content, model, api_key)
     },
     
     #' @description
@@ -85,30 +39,7 @@ OpenRouterProcessor <- R6::R6Class("OpenRouterProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing OpenRouter API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from OpenRouter API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from OpenRouter API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/R/qwen_processor.R
+++ b/R/R/qwen_processor.R
@@ -20,18 +20,15 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
     #
     test_endpoint = function(url, api_key) {
       tryCatch({
-        # Simple test payload with correct Qwen format
+        # Simple OpenAI-compatible test payload. Region-specific DashScope
+        # keys can return 401/403 on the wrong regional host, so keep probing
+        # alternatives for those statuses.
         test_payload <- list(
           model = "qwen-turbo",
-          input = list(
-            messages = list(
-              list(role = "user", content = "test")
-            )
+          messages = list(
+            list(role = "user", content = "test")
           ),
-          parameters = list(
-            max_tokens = 1,
-            temperature = 0.1
-          )
+          max_tokens = 1
         )
 
         response <- httr::POST(
@@ -45,7 +42,10 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
           httr::timeout(10)  # 10 second timeout for quick test
         )
 
-        return(httr::status_code(response) == 200)
+        status_code <- httr::status_code(response)
+        return(!is.null(status_code) &&
+                 !(status_code %in% c(401, 403, 404)) &&
+                 status_code < 500)
       }, error = function(e) {
         return(FALSE)
       })
@@ -61,14 +61,15 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
     },
 
     #' @description
-    #' Get default Qwen API URL with intelligent endpoint selection
+    #' Get default Qwen OpenAI-compatible chat completions API URL
     #
-    #' @details Qwen has two API endpoints:
-    #'   - International: https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation (preferred)
-    #'   - Domestic (China): https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation (fallback)
-    #'   The processor automatically tries international first, then falls back to domestic if needed.
+    #' @details Qwen has OpenAI-compatible chat completions endpoints:
+    #'   - International (US): https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions
+    #'   - Domestic (China): https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+    #'   - Legacy international: https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions
+    #'   The processor automatically tries international first, then domestic, then legacy international.
     get_default_api_url = function() {
-      return("https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation")
+      return("https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions")
     },
 
     #' @description
@@ -81,28 +82,33 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
         return(get(cache_key, envir = .qwen_endpoint_cache, inherits = FALSE))
       }
 
-      international_url <- "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
-      domestic_url <- "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+      endpoints <- list(
+        international = "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions",
+        domestic = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+        legacy_international = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+      )
 
       self$logger$debug("Testing Qwen endpoints for accessibility")
 
-      # Try international endpoint first
-      if (private$test_endpoint(international_url, api_key)) {
-        self$logger$info("Using Qwen international endpoint", list(url = international_url))
-        assign(cache_key, international_url, envir = .qwen_endpoint_cache)
-        return(international_url)
+      for (endpoint_name in names(endpoints)) {
+        endpoint_url <- endpoints[[endpoint_name]]
+        if (private$test_endpoint(endpoint_url, api_key)) {
+          self$logger$info(
+            sprintf("Using Qwen %s endpoint", endpoint_name),
+            list(url = endpoint_url)
+          )
+          assign(cache_key, endpoint_url, envir = .qwen_endpoint_cache)
+          return(endpoint_url)
+        }
       }
 
-      # Fallback to domestic endpoint
-      if (private$test_endpoint(domestic_url, api_key)) {
-        self$logger$info("Using Qwen domestic endpoint (international failed)", list(url = domestic_url))
-        assign(cache_key, domestic_url, envir = .qwen_endpoint_cache)
-        return(domestic_url)
-      }
-
-      # If both fail, return international as default and let the main call handle the error
-      self$logger$warn("Both Qwen endpoints failed during testing, using international as default")
-      return(international_url)
+      # If all probes fail, return international as default and let the main call
+      # handle the error.
+      self$logger$warn(
+        "All Qwen endpoints failed during testing, using international as default"
+      )
+      assign(cache_key, endpoints$international, envir = .qwen_endpoint_cache)
+      return(endpoints$international)
     },
     
     #' @description
@@ -112,26 +118,6 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body with proper Qwen format
-      body <- list(
-        model = model,
-        input = list(
-          messages = list(
-            list(
-              role = "user",
-              content = chunk_content
-            )
-          )
-        ),
-        parameters = list(
-          max_tokens = 2000,
-          temperature = 0.1
-        )
-      )
-      
-      self$logger$debug("Sending API request to Qwen",
-                       list(model = model, provider = self$provider_name))
-      
       # Get API URL: custom base_url takes priority, otherwise auto-detect endpoint
       api_url <- if (!is.null(self$base_url)) {
         self$base_url
@@ -139,39 +125,16 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
         self$get_working_api_url(api_key)
       }
 
-      # Make the API request
-      response <- httr::POST(
-        url = api_url,
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
+      private$post_chat_completions_request(
+        chunk_content,
+        model,
+        api_key,
+        api_url = api_url,
+        body_extra = list(
+          temperature = 0.7,
+          max_tokens = 4096
         )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("Qwen API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("Qwen API request failed: %s", error_message))
-      }
-      
-      return(response)
+      )
     },
     
     #' @description
@@ -186,9 +149,13 @@ QwenProcessor <- R6::R6Class("QwenProcessor",
       # Parse the response
       content <- httr::content(response, "parsed")
 
-      # Extract from Qwen's format: older models use output$text,
-      # newer models (qwen3-*) use output$choices[[1]]$message$content
-      if (!is.null(content$output$text)) {
+      # Extract from the current OpenAI-compatible format first, then retain
+      # legacy DashScope format support for older cached/mocked responses.
+      if (!is.null(content$choices) &&
+          length(content$choices) > 0 &&
+          !is.null(content$choices[[1]]$message$content)) {
+        response_content <- content$choices[[1]]$message$content
+      } else if (!is.null(content$output$text)) {
         response_content <- content$output$text
       } else if (!is.null(content$output$choices) &&
                  length(content$output$choices) > 0 &&

--- a/R/R/stepfun_processor.R
+++ b/R/R/stepfun_processor.R
@@ -30,53 +30,15 @@ StepFunProcessor <- R6::R6Class("StepFunProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
+      private$post_chat_completions_request(
+        chunk_content,
+        model,
+        api_key,
+        body_extra = list(
+          temperature = 0.7,
+          max_tokens = 4096
         )
       )
-      
-      self$logger$debug("Sending API request to StepFun",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("StepFun API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("StepFun API request failed: %s", error_message))
-      }
-      
-      return(response)
     },
     
     #' @description
@@ -85,30 +47,7 @@ StepFunProcessor <- R6::R6Class("StepFunProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing StepFun API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from StepFun API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from StepFun API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/R/url_utils.R
+++ b/R/R/url_utils.R
@@ -3,6 +3,49 @@
 #' This file contains utility functions for resolving custom base URLs
 #' for different API providers.
 
+#' Validate base URL
+#'
+#' @param url URL string to validate
+#' @return TRUE if the URL is a safe HTTP(S) endpoint, otherwise FALSE
+#' @keywords internal
+#' @noRd
+validate_base_url <- function(url) {
+  if (!is.character(url) || length(url) != 1 || is.na(url)) {
+    return(FALSE)
+  }
+
+  normalized <- trimws(url)
+  if (!nzchar(normalized) || grepl("\\s", normalized)) {
+    return(FALSE)
+  }
+
+  parsed <- tryCatch(
+    httr::parse_url(normalized),
+    error = function(e) NULL
+  )
+  if (is.null(parsed)) {
+    return(FALSE)
+  }
+
+  if (is.null(parsed$scheme) || !parsed$scheme %in% c("http", "https")) {
+    return(FALSE)
+  }
+  if (is.null(parsed$hostname) || !nzchar(parsed$hostname)) {
+    return(FALSE)
+  }
+  if (!is.null(parsed$username) || !is.null(parsed$password)) {
+    return(FALSE)
+  }
+  if (!is.null(parsed$query) && length(parsed$query) > 0) {
+    return(FALSE)
+  }
+  if (!is.null(parsed$fragment) && nzchar(parsed$fragment)) {
+    return(FALSE)
+  }
+
+  TRUE
+}
+
 #' Resolve provider-specific base URL
 #'
 #' This is the single entry point for all base URL resolution. It resolves
@@ -13,24 +56,57 @@
 #' @return Resolved and normalized base URL, or NULL if not specified
 #' @keywords internal
 resolve_provider_base_url <- function(provider, base_urls) {
-  if (is.null(base_urls)) {
+  normalize_value <- function(value, source) {
+    if (is.null(value)) {
+      return(NULL)
+    }
+    if (!is.character(value) || length(value) != 1 || is.na(value)) {
+      stop(sprintf("base_urls%s must be a string URL", source))
+    }
+
+    normalized <- sub("/+$", "", trimws(value))
+    if (!nzchar(normalized)) {
+      return(NULL)
+    }
+    if (!validate_base_url(normalized)) {
+      stop(sprintf("Invalid base URL in base_urls%s: %s", source, value))
+    }
+    normalized
+  }
+
+  if (is.null(base_urls) || is.null(provider)) {
     return(NULL)
   }
 
-  url <- NULL
+  if (!is.character(provider) || length(provider) != 1 || is.na(provider)) {
+    return(NULL)
+  }
+
+  provider_normalized <- tolower(trimws(provider))
+  if (!nzchar(provider_normalized)) {
+    return(NULL)
+  }
 
   if (is.character(base_urls) && length(base_urls) == 1) {
-    url <- base_urls
-  } else if (is.list(base_urls) && provider %in% names(base_urls)) {
-    url <- base_urls[[provider]]
+    return(normalize_value(base_urls, ""))
   }
 
-  if (is.null(url)) {
-    return(NULL)
+  if (is.list(base_urls)) {
+    base_url_names <- names(base_urls)
+    if (is.null(base_url_names)) {
+      return(NULL)
+    }
+
+    normalized_names <- tolower(trimws(base_url_names))
+    match_idx <- match(provider_normalized, normalized_names)
+    if (is.na(match_idx)) {
+      return(NULL)
+    }
+    return(normalize_value(
+      base_urls[[match_idx]],
+      sprintf("[['%s']]", base_url_names[[match_idx]])
+    ))
   }
 
-  # Normalize: strip trailing slashes for consistency
-  url <- sub("/+$", "", url)
-
-  return(url)
+  stop("base_urls must be NULL, a single string URL, or a named list")
 }

--- a/R/R/zhipu_processor.R
+++ b/R/R/zhipu_processor.R
@@ -30,53 +30,15 @@ ZhipuProcessor <- R6::R6Class("ZhipuProcessor",
     #
     #
     make_api_call = function(chunk_content, model, api_key) {
-      # Prepare request body
-      body <- list(
-        model = model,
-        messages = list(
-          list(
-            role = "user",
-            content = chunk_content
-          )
+      private$post_chat_completions_request(
+        chunk_content,
+        model,
+        api_key,
+        body_extra = list(
+          temperature = 0.7,
+          max_tokens = 4096
         )
       )
-      
-      self$logger$debug("Sending API request to Zhipu",
-                       list(model = model, provider = self$provider_name))
-      
-      # Make the API request
-      response <- httr::POST(
-        url = self$get_api_url(),
-        httr::add_headers(
-          "Authorization" = paste("Bearer", api_key),
-          "Content-Type" = "application/json"
-        ),
-        body = jsonlite::toJSON(body, auto_unbox = TRUE),
-        encode = "json"
-      )
-      
-      # Check for HTTP errors
-      if (httr::http_error(response)) {
-        error_content <- tryCatch(
-          httr::content(response, "parsed"),
-          error = function(e) NULL
-        )
-        error_message <- if (is.list(error_content) && !is.null(error_content$error$message)) {
-          error_content$error$message
-        } else {
-          sprintf("HTTP %d error", httr::status_code(response))
-        }
-        
-        self$logger$error("Zhipu API request failed",
-                         list(error = error_message,
-                              provider = self$provider_name,
-                              model = model,
-                              status_code = httr::status_code(response)))
-        
-        stop(sprintf("Zhipu API request failed: %s", error_message))
-      }
-      
-      return(response)
     },
     
     #' @description
@@ -85,30 +47,7 @@ ZhipuProcessor <- R6::R6Class("ZhipuProcessor",
     #
     #
     extract_response_content = function(response, model) {
-      self$logger$debug("Parsing Zhipu API response",
-                       list(provider = self$provider_name, model = model))
-      
-      # Parse the response
-      content <- httr::content(response, "parsed")
-      
-      # Check if response has the expected structure
-      if (is.null(content) || is.null(content$choices) || length(content$choices) == 0 ||
-          is.null(content$choices[[1]]$message) || is.null(content$choices[[1]]$message$content)) {
-        
-        self$logger$error("Unexpected response format from Zhipu API",
-                         list(provider = self$provider_name,
-                              model = model,
-                              content_structure = names(content),
-                              choices_available = !is.null(content$choices),
-                              choices_count = if(!is.null(content$choices)) length(content$choices) else 0))
-        
-        stop("Unexpected response format from Zhipu API")
-      }
-      
-      # Extract the response content
-      response_content <- content$choices[[1]]$message$content
-      
-      return(response_content)
+      private$extract_chat_completions_content(response, model)
     }
   )
 )

--- a/R/man/MinimaxProcessor.Rd
+++ b/R/man/MinimaxProcessor.Rd
@@ -47,7 +47,7 @@ Initialize Minimax processor
 \if{html}{\out{<a id="method-MinimaxProcessor-get_default_api_url"></a>}}
 \if{latex}{\out{\hypertarget{method-MinimaxProcessor-get_default_api_url}{}}}
 \subsection{Method \code{get_default_api_url()}}{
-Get default Minimax API URL
+Get default MiniMax OpenAI-compatible chat completions API URL
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{MinimaxProcessor$get_default_api_url()}\if{html}{\out{</div>}}
 }

--- a/R/man/QwenProcessor.Rd
+++ b/R/man/QwenProcessor.Rd
@@ -12,11 +12,12 @@ Qwen API Processor
 Concrete implementation of BaseAPIProcessor for Qwen models.
 Handles Qwen-specific API calls, authentication, and response parsing.
 
-Qwen has two API endpoints:
+Qwen has OpenAI-compatible chat completions endpoints:
 \itemize{
-\item International: https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation (preferred)
-\item Domestic (China): https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation (fallback)
-The processor automatically tries international first, then falls back to domestic if needed.
+\item International (US): https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions
+\item Domestic (China): https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+\item Legacy international: https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions
+The processor automatically tries international first, then domestic, then legacy international.
 }
 }
 \section{Super class}{
@@ -58,7 +59,7 @@ Initialize Qwen processor
 \if{html}{\out{<a id="method-QwenProcessor-get_default_api_url"></a>}}
 \if{latex}{\out{\hypertarget{method-QwenProcessor-get_default_api_url}{}}}
 \subsection{Method \code{get_default_api_url()}}{
-Get default Qwen API URL with intelligent endpoint selection
+Get default Qwen OpenAI-compatible chat completions API URL
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{QwenProcessor$get_default_api_url()}\if{html}{\out{</div>}}
 }

--- a/R/man/resolve_provider_base_url.Rd
+++ b/R/man/resolve_provider_base_url.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/url_utils.R
 \name{resolve_provider_base_url}
 \alias{resolve_provider_base_url}
-\title{URL Utilities for Base URL Resolution}
+\title{Resolve provider-specific base URL}
 \usage{
 resolve_provider_base_url(provider, base_urls)
 }
@@ -15,11 +15,6 @@ resolve_provider_base_url(provider, base_urls)
 Resolved and normalized base URL, or NULL if not specified
 }
 \description{
-This file contains utility functions for resolving custom base URLs
-for different API providers.
-Resolve provider-specific base URL
-}
-\details{
 This is the single entry point for all base URL resolution. It resolves
 the appropriate URL and normalizes it (strips trailing slashes).
 }

--- a/R/tests/testthat/test-input-contract-consistency.R
+++ b/R/tests/testthat/test-input-contract-consistency.R
@@ -1,5 +1,28 @@
 # Input contract consistency tests
 
+make_test_json_response <- function(payload,
+                                    status_code = 200L,
+                                    url = "https://example.test/v1/chat/completions") {
+  structure(
+    list(
+      url = url,
+      status_code = status_code,
+      headers = list("Content-Type" = "application/json"),
+      all_headers = list(list(
+        status = status_code,
+        version = "HTTP/1.1",
+        headers = list("Content-Type" = "application/json")
+      )),
+      cookies = data.frame(),
+      content = charToRaw(jsonlite::toJSON(payload, auto_unbox = TRUE)),
+      date = Sys.time(),
+      times = c(),
+      request = list(method = "POST")
+    ),
+    class = "response"
+  )
+}
+
 test_that("normalize_cluster_gene_list canonicalizes list inputs", {
   unnamed <- normalize_cluster_gene_list(list(c("G1"), c("G2")))
   expect_identical(names(unnamed), c("0", "1"))
@@ -561,6 +584,39 @@ test_that("QwenProcessor caches endpoint selection per API key", {
   expect_identical(processor$get_working_api_url("key-b"), "https://domestic.example.test")
 })
 
+test_that("resolve_provider_base_url matches Python URL contract", {
+  expect_null(resolve_provider_base_url("openai", NULL))
+  expect_null(resolve_provider_base_url("openai", list(anthropic = "https://anthropic.example.test/v1")))
+
+  expect_identical(
+    resolve_provider_base_url("  OPENAI  ", "  https://proxy.example.test/v1/  "),
+    "https://proxy.example.test/v1"
+  )
+  expect_identical(
+    resolve_provider_base_url(
+      "openai",
+      list("  OpenAI  " = "https://openai-proxy.example.test/v1/chat/completions/")
+    ),
+    "https://openai-proxy.example.test/v1/chat/completions"
+  )
+
+  expect_error(resolve_provider_base_url("openai", "not-a-url"), "Invalid base URL")
+  expect_error(resolve_provider_base_url("openai", "https://api.example.test/v1?token=abc"), "Invalid base URL")
+  expect_error(resolve_provider_base_url("openai", list(openai = 123)), "must be a string URL")
+  expect_error(resolve_provider_base_url("openai", c("https://a.example", "https://b.example")), "base_urls must be")
+})
+
+test_that("provider default endpoints use current OpenAI-compatible chat APIs", {
+  expect_identical(
+    QwenProcessor$new()$get_default_api_url(),
+    "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
+  )
+  expect_identical(
+    MinimaxProcessor$new()$get_default_api_url(),
+    "https://api.minimax.io/v1/chat/completions"
+  )
+})
+
 
 test_that("BaseAPIProcessor rejects non-scalar prompt cleanly", {
   TP <- R6::R6Class(
@@ -580,7 +636,141 @@ test_that("BaseAPIProcessor rejects non-scalar prompt cleanly", {
   )
 })
 
+test_that("BaseAPIProcessor shared chat completion helpers keep canonical contract", {
+  testthat::with_mocked_bindings({
+    HelperProcessor <- R6::R6Class(
+      "HelperProcessor",
+      inherit = BaseAPIProcessor,
+      public = list(
+        initialize = function() super$initialize("openai", NULL),
+        get_default_api_url = function() "https://example.test/v1/chat/completions",
+        make_api_call = function(chunk_content, model, api_key) NULL,
+        extract_response_content = function(response, model) NULL,
+        build_body_for_test = function() {
+          private$build_chat_completions_body(
+            "genes",
+            "gpt-5.5",
+            extra = list(stream = FALSE)
+          )
+        },
+        extract_content_for_test = function(payload) {
+          private$extract_chat_completions_content(
+            make_test_json_response(payload),
+            "gpt-5.5"
+          )
+        }
+      )
+    )
+
+    processor <- HelperProcessor$new()
+    body <- processor$build_body_for_test()
+    expect_identical(body$model, "gpt-5.5")
+    expect_identical(body$messages[[1]], list(role = "user", content = "genes"))
+    expect_identical(body$stream, FALSE)
+    expect_identical(
+      processor$extract_content_for_test(list(
+        choices = list(list(message = list(content = "T cell\nB cell")))
+      )),
+      "T cell\nB cell"
+    )
+  },
+  get_logger = function() {
+    list(
+      info = function(...) NULL,
+      debug = function(...) NULL,
+      error = function(...) NULL
+    )
+  })
+})
+
+test_that("BaseAPIProcessor extracts provider error messages from common shapes", {
+  testthat::with_mocked_bindings({
+    HelperProcessor <- R6::R6Class(
+      "HelperProcessor",
+      inherit = BaseAPIProcessor,
+      public = list(
+        initialize = function() super$initialize("openai", NULL),
+        get_default_api_url = function() "https://example.test/v1/chat/completions",
+        make_api_call = function(chunk_content, model, api_key) NULL,
+        extract_response_content = function(response, model) NULL,
+        error_for_test = function(payload) {
+          private$extract_error_message(make_test_json_response(payload, status_code = 400L))
+        }
+      )
+    )
+
+    processor <- HelperProcessor$new()
+    expect_identical(
+      processor$error_for_test(list(error = list(message = "nested error"))),
+      "nested error"
+    )
+    expect_identical(
+      processor$error_for_test(list(error = "flat error")),
+      "flat error"
+    )
+    expect_identical(
+      processor$error_for_test(list(message = "top-level error")),
+      "top-level error"
+    )
+    expect_identical(
+      processor$error_for_test(list(error = list(message = NA_character_))),
+      "HTTP 400 error"
+    )
+  },
+  get_logger = function() {
+    list(
+      info = function(...) NULL,
+      debug = function(...) NULL,
+      error = function(...) NULL
+    )
+  })
+})
+
+test_that("MiniMax business error without status message is stable", {
+  response <- make_test_json_response(
+    list(base_resp = list(status_code = 1001, status_msg = NA_character_))
+  )
+
+  testthat::with_mocked_bindings({
+    expect_error(
+      MinimaxProcessor$new()$extract_response_content(response, "MiniMax-M2.7"),
+      "MiniMax API error: Unknown MiniMax API error"
+    )
+  },
+  get_logger = function() {
+    list(
+      info = function(...) NULL,
+      debug = function(...) NULL,
+      error = function(...) NULL
+    )
+  })
+})
+
+test_that("MiniMax strips think blocks from OpenAI-compatible content", {
+  response <- make_test_json_response(
+    list(
+      choices = list(list(message = list(
+        content = "<think>internal reasoning</think>\nCELL TYPE: T cell"
+      )))
+    )
+  )
+
+  testthat::with_mocked_bindings({
+    result <- MinimaxProcessor$new()$extract_response_content(response, "MiniMax-M2.7")
+    expect_identical(result, "CELL TYPE: T cell")
+  },
+  get_logger = function() {
+    list(
+      info = function(...) NULL,
+      debug = function(...) NULL,
+      error = function(...) NULL
+    )
+  })
+})
+
 test_that("get_provider validates model as non-empty scalar", {
+  expect_identical(get_provider("  gpt-5.5  "), "openai")
+  expect_identical(get_provider("  anthropic/claude-opus-4.7  "), "openrouter")
   expect_error(get_provider(character(0)), "model must be a non-empty character scalar")
   expect_error(get_provider(c("gpt-5.5", "grok-4.3")), "model must be a non-empty character scalar")
   expect_error(get_provider(NA_character_), "model must be a non-empty character scalar")
@@ -618,6 +808,35 @@ test_that("get_api_key ignores empty/NA/non-scalar keys and falls back correctly
   expect_null(get_api_key("gpt-5.5", list(openai = c("a", "b"))))
   expect_identical(get_api_key("gpt-5.5", list(openai = "", "gpt-5.5" = "k2")), "k2")
   expect_identical(get_api_key("gpt-5.5", list(openai = "  k1  ")), "k1")
+  expect_identical(get_api_key("  gpt-5.5  ", list(" OpenAI " = "  k1  ")), "k1")
+  expect_identical(get_api_key("  gpt-5.5  ", list(" GPT-5.5 " = "  k2  ")), "k2")
+})
+
+test_that("model and api_key are trimmed before R provider dispatch", {
+  direct_result <- testthat::with_mocked_bindings({
+    get_model_response("prompt", "  gpt-5.5  ", "  key  ")
+  },
+  process_openai = function(prompt, model, api_key, base_url = NULL) {
+    expect_identical(model, "gpt-5.5")
+    expect_identical(api_key, "key")
+    "ok"
+  })
+  expect_identical(direct_result, "ok")
+
+  public_result <- testthat::with_mocked_bindings({
+    suppressMessages(annotate_cell_types(
+      input = list("0" = list(genes = c("CD3D"))),
+      tissue_name = "PBMC",
+      model = "  gpt-5.5  ",
+      api_key = "  key  "
+    ))
+  },
+  get_model_response = function(prompt, model, api_key, base_urls = NULL) {
+    expect_identical(model, "gpt-5.5")
+    expect_identical(api_key, "key")
+    c("T cell")
+  })
+  expect_identical(public_result, c("T cell"))
 })
 
 test_that("facilitate_cluster_discussion uses last available consensus on early break", {

--- a/README_CN.md
+++ b/README_CN.md
@@ -491,7 +491,7 @@ results <- annotate_cell_types(
   base_urls = list(
     openai = "https://openai-proxy.com/v1",
     anthropic = "https://anthropic-proxy.com/v1",
-    qwen = "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+    qwen = "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
   )
 )
 
@@ -1475,7 +1475,7 @@ result <- annotate_cell_types(
   base_urls = list(
     openai = "https://openai-proxy.com/v1",
     anthropic = "https://anthropic-proxy.com/v1",
-    qwen = "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation"  # 国际版
+    qwen = "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"  # 国际版
   )
 )
 ```
@@ -1496,7 +1496,7 @@ consensus_results <- interactive_consensus_annotation(
   base_urls = list(
     openai = "https://openai-proxy.com/v1",
     anthropic = "https://anthropic-proxy.com/v1",
-    qwen = "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+    qwen = "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
   )
 )
 ```
@@ -1505,15 +1505,17 @@ consensus_results <- interactive_consensus_annotation(
 
 **新功能**：Qwen模型现在支持智能端点选择，自动检测最佳可用端点！
 
-Qwen有两个API端点：
-- **国际版**：`https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/text-generation/generation`
-- **国内版**：`https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation`
+Qwen有多个API端点：
+- **国际版**：`https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions`
+- **国内版**：`https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions`
+- **旧国际版兼容兜底**：`https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions`
 
 **智能选择机制**：
-1. 🔍 首先尝试国际版端点
+1. 🔍 首先尝试当前国际版端点
 2. 🔄 如果国际版无法访问，自动切换到国内版
-3. 💾 缓存工作的端点，避免重复检测
-4. ⚡ 后续调用直接使用已验证的端点
+3. 🧭 必要时尝试旧国际版兼容端点
+4. 💾 缓存工作的端点，避免重复检测
+5. ⚡ 后续调用直接使用已验证的端点
 
 ```r
 # 推荐用法：让系统自动选择端点
@@ -1544,7 +1546,7 @@ result <- annotate_cell_types(
   tissue_name = "human PBMC",
   model = "qwen3.6-plus",
   api_key = "your-qwen-api-key",
-  base_urls = list(qwen = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation")  # 强制使用国内版
+  base_urls = list(qwen = "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions")  # 强制使用国内版
 )
 ```
 

--- a/python/mllmcelltype/config.py
+++ b/python/mllmcelltype/config.py
@@ -50,7 +50,7 @@ PROVIDER_CONFIGS: dict[str, ProviderConfig] = {
     "qwen": ProviderConfig(
         default_model="qwen3.6-plus",
         api_key_env_var="QWEN_API_KEY",
-        default_api_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+        default_api_url="https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions",
     ),
     "stepfun": ProviderConfig(
         default_model="step-3.5-flash",
@@ -65,7 +65,7 @@ PROVIDER_CONFIGS: dict[str, ProviderConfig] = {
     "minimax": ProviderConfig(
         default_model="MiniMax-M2.7",
         api_key_env_var="MINIMAX_API_KEY",
-        default_api_url="https://api.minimaxi.com/v1/chat/completions",
+        default_api_url="https://api.minimax.io/v1/chat/completions",
     ),
     "grok": ProviderConfig(
         default_model="grok-4.3",

--- a/python/mllmcelltype/providers/common.py
+++ b/python/mllmcelltype/providers/common.py
@@ -147,7 +147,7 @@ def resolve_endpoint_url(
                 f"Invalid base URL type for {provider_name}: "
                 f"expected str or None, got {type(base_url).__name__}"
             )
-        normalized_base_url = base_url.strip()
+        normalized_base_url = base_url.strip().rstrip("/")
         if normalized_base_url:
             if not validate_base_url(normalized_base_url):
                 raise ValueError(f"Invalid base URL: {base_url}")

--- a/python/mllmcelltype/url_utils.py
+++ b/python/mllmcelltype/url_utils.py
@@ -47,7 +47,7 @@ def resolve_provider_base_url(provider: str, base_urls: str | dict | None) -> st
             return None
         if not isinstance(value, str):
             raise ValueError(f"base_urls{source} must be a string URL, got {type(value).__name__}")
-        normalized = value.strip()
+        normalized = value.strip().rstrip("/")
         if normalized and not validate_base_url(normalized):
             raise ValueError(f"Invalid base URL in base_urls{source}: {value}")
         return normalized or None
@@ -220,23 +220,31 @@ def get_working_qwen_endpoint(api_key: str) -> str:
 
             response = requests.post(endpoint, headers=headers, json=test_body, timeout=timeout)
 
-            # Any HTTP response indicates the endpoint is network-reachable
-            # 200: success, 400: bad request, 401/403: auth error - all mean endpoint works
-            # Only connection failures (timeout, DNS error, etc.) indicate unreachable endpoint
-            return response.status_code is not None
+            # Choose an endpoint likely to accept this key. Region-specific
+            # DashScope keys can return 401/403 on the wrong regional host.
+            status_code = response.status_code
+            if status_code in {401, 403, 404}:
+                return False
+            return status_code is not None and status_code < 500
 
         except requests.RequestException:
             return False
 
     endpoints = [
-        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",  # International
-        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",  # Domestic (China)
+        (
+            "international",
+            "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions",
+        ),
+        ("domestic", "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"),
+        (
+            "legacy international",
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+        ),
     ]
 
     write_log("Testing Qwen endpoint connectivity...", level="debug")
 
-    for i, endpoint in enumerate(endpoints):
-        endpoint_type = "international" if i == 0 else "domestic"
+    for endpoint_type, endpoint in endpoints:
         write_log(f"Testing {endpoint_type} endpoint: {endpoint}", level="debug")
 
         if test_endpoint_connectivity(endpoint, api_key):
@@ -248,5 +256,6 @@ def get_working_qwen_endpoint(api_key: str) -> str:
 
     # If none are reachable, return international endpoint as fallback
     write_log("No endpoints accessible, using international endpoint as fallback")
-    _SMART_ENDPOINT_CACHE[cache_key] = endpoints[0]
-    return endpoints[0]
+    fallback_endpoint = endpoints[0][1]
+    _SMART_ENDPOINT_CACHE[cache_key] = fallback_endpoint
+    return fallback_endpoint

--- a/python/mllmcelltype/utils.py
+++ b/python/mllmcelltype/utils.py
@@ -711,16 +711,6 @@ def format_results(
             # Extract JSON content or use full text
             json_str = json_match.group(1) if json_match else full_text
 
-        # Fix common JSON formatting issues
-        # Add missing commas between JSON objects
-        json_str = re.sub(r'("[^"]+")\s*\n\s*("[^"]+")', r"\1,\n\2", json_str)
-        # Add missing commas after closing brackets
-        json_str = re.sub(r'(\])\s*\n\s*("[^"]+")', r"\1,\n\2", json_str)
-        # Add missing commas after closing braces
-        json_str = re.sub(r'(\})\s*\n\s*("[^"]+")', r"\1,\n\2", json_str)
-        # Add missing commas after closing braces before opening braces
-        json_str = re.sub(r"(\})\s*\n\s*(\{)", r"\1,\n\2", json_str)
-
         # Parse JSON
         data = json.loads(json_str)
 

--- a/python/tests/test_base_url_integration.py
+++ b/python/tests/test_base_url_integration.py
@@ -212,7 +212,7 @@ class TestQwenSmartEndpointSelection:
         assert mock_test_post.call_count >= 1
         # First call should be the endpoint connectivity test
         first_call_args = mock_test_post.call_args_list[0]
-        assert "dashscope-intl.aliyuncs.com" in first_call_args[0][0]
+        assert "dashscope-us.aliyuncs.com" in first_call_args[0][0]
 
         # Verify actual API call used the international endpoint
         # Note: Both mocks may capture calls since they share the same requests module
@@ -221,12 +221,12 @@ class TestQwenSmartEndpointSelection:
         for call in all_calls:
             if (
                 call[1].get("url")
-                == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+                == "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
             ):
                 api_call_found = True
                 break
             # Also check positional args
-            if call[0] and "dashscope-intl" in str(call[0]):
+            if call[0] and "dashscope-us" in str(call[0]):
                 api_call_found = True
                 break
         assert api_call_found, "Expected international endpoint to be used"

--- a/python/tests/test_providers_common.py
+++ b/python/tests/test_providers_common.py
@@ -323,7 +323,11 @@ def test_call_openai_compatible_api_merges_extra_headers():
 
 def test_resolve_endpoint_url_trims_custom_base_url():
     """Test custom endpoint URL is stripped before validation/use."""
-    result = resolve_endpoint_url("openai", "OpenAI", "  https://proxy.example.com/v1/chat/completions  ")
+    result = resolve_endpoint_url(
+        "openai",
+        "OpenAI",
+        "  https://proxy.example.com/v1/chat/completions/  ",
+    )
     assert result == "https://proxy.example.com/v1/chat/completions"
 
 

--- a/python/tests/test_url_utils.py
+++ b/python/tests/test_url_utils.py
@@ -38,8 +38,8 @@ class TestResolveProviderBaseUrl:
         assert result == base_url
 
     def test_resolve_with_string_trims_whitespace(self):
-        """Test resolving with string base_urls trims leading/trailing spaces."""
-        result = resolve_provider_base_url("openai", "  https://proxy.example.com/v1  ")
+        """Test resolving with string base_urls trims spaces and trailing slashes."""
+        result = resolve_provider_base_url("openai", "  https://proxy.example.com/v1/  ")
         assert result == "https://proxy.example.com/v1"
 
     def test_resolve_with_dict_existing_provider(self):
@@ -71,7 +71,7 @@ class TestResolveProviderBaseUrl:
 
     def test_resolve_with_whitespace_provider_key(self):
         """Test provider key with whitespace in dict is normalized."""
-        base_urls = {"  openai  ": "https://openai-proxy.com/v1/chat/completions"}
+        base_urls = {"  openai  ": "https://openai-proxy.com/v1/chat/completions/"}
         result = resolve_provider_base_url("openai", base_urls)
         assert result == "https://openai-proxy.com/v1/chat/completions"
 
@@ -117,7 +117,7 @@ class TestGetDefaultApiUrl:
     def test_get_qwen_url(self):
         """Test getting Qwen default URL."""
         result = get_default_api_url("qwen")
-        assert result == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+        assert result == "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
 
     def test_get_deepseek_url(self):
         """Test getting DeepSeek default URL."""
@@ -152,7 +152,7 @@ class TestGetDefaultApiUrl:
     def test_get_minimax_url(self):
         """Test getting MiniMax default URL."""
         result = get_default_api_url("minimax")
-        assert result == "https://api.minimaxi.com/v1/chat/completions"
+        assert result == "https://api.minimax.io/v1/chat/completions"
 
     def test_get_unknown_provider(self):
         """Test getting URL for unknown provider."""
@@ -218,7 +218,7 @@ class TestGetWorkingQwenEndpoint:
 
         result = get_working_qwen_endpoint("test-api-key")
 
-        assert result == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+        assert result == "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
         mock_post.assert_called_once()
 
     @patch("mllmcelltype.url_utils.requests.post")
@@ -228,7 +228,7 @@ class TestGetWorkingQwenEndpoint:
 
         # Mock failed response for international, success for domestic
         def side_effect(*args, **kwargs):
-            if "dashscope-intl" in args[0]:
+            if "dashscope-us" in args[0]:
                 raise requests.RequestException("Connection failed")
             else:
                 mock_response = MagicMock()
@@ -252,22 +252,25 @@ class TestGetWorkingQwenEndpoint:
         result = get_working_qwen_endpoint("test-api-key")
 
         # Should return international endpoint as fallback
-        assert result == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-        assert mock_post.call_count == 2
+        assert result == "https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions"
+        assert mock_post.call_count == 3
 
     @patch("mllmcelltype.url_utils.requests.post")
     @patch("mllmcelltype.url_utils.write_log")
-    def test_auth_error_considered_accessible(self, mock_log, mock_post):
-        """Test that authentication errors are considered as accessible endpoints."""
-        # Mock 401 response (auth error) for international endpoint
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        mock_post.return_value = mock_response
+    def test_auth_error_tries_next_region(self, mock_log, mock_post):
+        """Test that regional auth errors do not lock endpoint selection."""
+
+        def side_effect(*args, **kwargs):
+            mock_response = MagicMock()
+            mock_response.status_code = 401 if "dashscope-us" in args[0] else 200
+            return mock_response
+
+        mock_post.side_effect = side_effect
 
         result = get_working_qwen_endpoint("test-api-key")
 
-        assert result == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
-        mock_post.assert_called_once()
+        assert result == "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+        assert mock_post.call_count == 2
 
     @patch("mllmcelltype.url_utils.requests.post")
     @patch("mllmcelltype.url_utils.write_log")


### PR DESCRIPTION
## What changed

- Align Qwen and MiniMax with current OpenAI-compatible chat completion endpoints.
- Centralize R OpenAI-compatible provider request, response, and HTTP error handling.
- Normalize R/Python base URL, model, and API key input contracts.
- Add regression coverage for endpoint defaults, URL validation, trimming, and error parsing.

## Validation

- python3 -m pytest
- python3 -m ruff check
- Rscript -e 'setwd("R"); devtools::test()'\n- git diff --check\n- ./scripts/check-sensitive.sh\n