### PR TITLE
refactor(r): use standalone template for reasoning annotation prompt

### DIFF
--- a/R/R/prompt_templates.R
+++ b/R/R/prompt_templates.R
@@ -167,12 +167,11 @@ extract_cluster_genes_for_discussion <- function(input, cluster_id, top_gene_cou
   )
 }
 
-#' Normalize annotation inputs for the reasoning prompt
+#' Prepare normalized data for annotation prompts
 #'
-#' Input handling for create_reasoning_annotation_prompt(), mirroring the
-#' normalization done inside create_annotation_prompt() so the reasoning
-#' prompt sees the same canonical cluster ordering and gene formatting
-#' without depending on the base prompt's text.
+#' This is the single input-normalization path shared by the standard and
+#' reasoning annotation prompts. Prompt renderers consume the returned data
+#' without duplicating validation, marker selection, or cluster ordering.
 #'
 #' @param input Either a data frame from Seurat's FindAllMarkers() or a list for each cluster
 #'   where each element is either a character vector of genes or a list containing a `genes` field
@@ -199,7 +198,7 @@ prepare_annotation_prompt_data <- function(input, tissue_name, top_gene_count) {
       genes <- normalized_input[[cluster_id]]
       gene_lists[[cluster_id]] <- paste(genes, collapse = ", ")
     }
-    
+
     expected_count <- length(normalized_input)
   } else if (is.data.frame(input)) {
     required_columns <- c("cluster", "gene", "avg_log2FC")
@@ -238,7 +237,7 @@ prepare_annotation_prompt_data <- function(input, tissue_name, top_gene_count) {
   } else {
     stop("Input must be either a data.frame (from Seurat) or a list of gene lists")
   }
-  
+
   cluster_names <- canonical_cluster_ids(gene_lists)
   gene_lists <- gene_lists[cluster_names]
 
@@ -267,75 +266,17 @@ prepare_annotation_prompt_data <- function(input, tissue_name, top_gene_count) {
 #'   (number of clusters), and `gene_lists` (cluster ID to marker genes mapping).
 #' @export
 create_annotation_prompt <- function(input, tissue_name, top_gene_count = 10) {
-  tissue_name <- .normalize_required_string(tissue_name, "tissue_name")
-  top_gene_count <- .normalize_top_gene_count(top_gene_count)
-
-  if (is.list(input) && !is.data.frame(input)) {
-    normalized_input <- normalize_cluster_gene_list(input)
-
-    gene_lists <- list()
-
-    for (cluster_id in names(normalized_input)) {
-      genes <- normalized_input[[cluster_id]]
-      gene_lists[[cluster_id]] <- paste(genes, collapse = ", ")
-    }
-    
-    expected_count <- length(normalized_input)
-  } else if (is.data.frame(input)) {
-    required_columns <- c("cluster", "gene", "avg_log2FC")
-    column_counts <- vapply(required_columns, function(column) {
-      sum(names(input) == column, na.rm = TRUE)
-    }, integer(1))
-    if (any(column_counts != 1)) {
-      stop(
-        "Data frame input must contain exactly one each of: ",
-        paste(required_columns, collapse = ", ")
-      )
-    }
-    if (!is.numeric(input$avg_log2FC)) {
-      stop("avg_log2FC must be numeric")
-    }
-
-    normalized_clusters <- trimws(as.character(input$cluster))
-    valid_cluster_rows <- !is.na(normalized_clusters) & nzchar(normalized_clusters)
-    if (any(!valid_cluster_rows)) {
-      warning("Skipping rows with missing or empty cluster IDs", call. = FALSE)
-    }
-    input <- input[valid_cluster_rows, , drop = FALSE]
-    normalized_clusters <- normalized_clusters[valid_cluster_rows]
-    if (nrow(input) == 0) {
-      stop("input must contain at least one valid cluster")
-    }
-
-    cluster_names <- unique(normalized_clusters)
-    gene_lists <- list()
-    for (cluster_id in cluster_names) {
-      genes <- select_cluster_marker_genes(input, cluster_id, top_gene_count)
-      gene_lists[[cluster_id]] <- paste(genes, collapse = ",")
-    }
-
-    expected_count <- length(gene_lists)
-  } else {
-    stop("Input must be either a data.frame (from Seurat) or a list of gene lists")
-  }
-  
-  cluster_names <- canonical_cluster_ids(gene_lists)
-  gene_lists <- gene_lists[cluster_names]
-
-  # Create formatted lines from gene_lists using the canonical cluster order.
-  formatted_lines <- vapply(cluster_names, function(name) {
-    paste0(name, ": ", gene_lists[[name]])
-  }, character(1), USE.NAMES = FALSE)
+  prompt_data <- prepare_annotation_prompt_data(input, tissue_name, top_gene_count)
 
   prompt <- paste0("You are a cell type annotation expert. Below are marker genes for different cell clusters in ", 
-                  tissue_name, ".\n\n",
-                  paste(formatted_lines, collapse = "\n"),
+                  prompt_data$tissue_name, ".\n\n",
+                  prompt_data$marker_text,
                   "\n\nReturn exactly one cell type name per line, in the same order as the clusters shown above, without cluster IDs or explanation.")
   
   return(list(
     prompt = prompt,
-    expected_count = expected_count,
-    gene_lists = gene_lists
+    expected_count = prompt_data$expected_count,
+    gene_lists = prompt_data$gene_lists
   ))
 }
 

--- a/R/R/prompt_templates.R
+++ b/R/R/prompt_templates.R
@@ -167,6 +167,94 @@ extract_cluster_genes_for_discussion <- function(input, cluster_id, top_gene_cou
   )
 }
 
+#' Normalize annotation inputs for the reasoning prompt
+#'
+#' Input handling for create_reasoning_annotation_prompt(), mirroring the
+#' normalization done inside create_annotation_prompt() so the reasoning
+#' prompt sees the same canonical cluster ordering and gene formatting
+#' without depending on the base prompt's text.
+#'
+#' @param input Either a data frame from Seurat's FindAllMarkers() or a list for each cluster
+#'   where each element is either a character vector of genes or a list containing a `genes` field
+#'   Cluster IDs in named inputs are preserved as-is; unnamed list input receives sequential IDs starting at "0".
+#' @param tissue_name Tissue context for the annotation (e.g., 'human PBMC', 'mouse brain')
+#' @param top_gene_count Number of top genes to use per cluster when input is from Seurat
+#'
+#' @return A list with `tissue_name` (normalized), `marker_text` (one
+#'   "cluster_id: gene1, gene2" line per cluster, in canonical order),
+#'   `expected_count` (number of clusters), and `gene_lists` (cluster ID to
+#'   marker genes mapping).
+#' @keywords internal
+#' @noRd
+prepare_annotation_prompt_data <- function(input, tissue_name, top_gene_count) {
+  tissue_name <- .normalize_required_string(tissue_name, "tissue_name")
+  top_gene_count <- .normalize_top_gene_count(top_gene_count)
+
+  if (is.list(input) && !is.data.frame(input)) {
+    normalized_input <- normalize_cluster_gene_list(input)
+
+    gene_lists <- list()
+
+    for (cluster_id in names(normalized_input)) {
+      genes <- normalized_input[[cluster_id]]
+      gene_lists[[cluster_id]] <- paste(genes, collapse = ", ")
+    }
+    
+    expected_count <- length(normalized_input)
+  } else if (is.data.frame(input)) {
+    required_columns <- c("cluster", "gene", "avg_log2FC")
+    column_counts <- vapply(required_columns, function(column) {
+      sum(names(input) == column, na.rm = TRUE)
+    }, integer(1))
+    if (any(column_counts != 1)) {
+      stop(
+        "Data frame input must contain exactly one each of: ",
+        paste(required_columns, collapse = ", ")
+      )
+    }
+    if (!is.numeric(input$avg_log2FC)) {
+      stop("avg_log2FC must be numeric")
+    }
+
+    normalized_clusters <- trimws(as.character(input$cluster))
+    valid_cluster_rows <- !is.na(normalized_clusters) & nzchar(normalized_clusters)
+    if (any(!valid_cluster_rows)) {
+      warning("Skipping rows with missing or empty cluster IDs", call. = FALSE)
+    }
+    input <- input[valid_cluster_rows, , drop = FALSE]
+    normalized_clusters <- normalized_clusters[valid_cluster_rows]
+    if (nrow(input) == 0) {
+      stop("input must contain at least one valid cluster")
+    }
+
+    cluster_names <- unique(normalized_clusters)
+    gene_lists <- list()
+    for (cluster_id in cluster_names) {
+      genes <- select_cluster_marker_genes(input, cluster_id, top_gene_count)
+      gene_lists[[cluster_id]] <- paste(genes, collapse = ",")
+    }
+
+    expected_count <- length(gene_lists)
+  } else {
+    stop("Input must be either a data.frame (from Seurat) or a list of gene lists")
+  }
+  
+  cluster_names <- canonical_cluster_ids(gene_lists)
+  gene_lists <- gene_lists[cluster_names]
+
+  # Create formatted lines from gene_lists using the canonical cluster order.
+  formatted_lines <- vapply(cluster_names, function(name) {
+    paste0(name, ": ", gene_lists[[name]])
+  }, character(1), USE.NAMES = FALSE)
+
+  return(list(
+    tissue_name = tissue_name,
+    marker_text = paste(formatted_lines, collapse = "\n"),
+    expected_count = expected_count,
+    gene_lists = gene_lists
+  ))
+}
+
 #' Create prompt for cell type annotation
 #'
 #' @param input Either a data frame from Seurat's FindAllMarkers() or a list for each cluster
@@ -253,6 +341,13 @@ create_annotation_prompt <- function(input, tissue_name, top_gene_count = 10) {
 
 #' Create reasoning-aware prompt for cell type annotation
 #'
+#' This prompt is built from its own template rather than derived from
+#' create_annotation_prompt(), so the two prompts can evolve independently.
+#' The template mirrors REASONING_PROMPT_TEMPLATE in the Python package
+#' (python/mllmcelltype/prompts.py) so both implementations ask for the same
+#' structured JSON output; it is adapted to the R signature, which takes a
+#' single `tissue_name` instead of separate species/tissue arguments.
+#'
 #' @param input Either a data frame from Seurat's FindAllMarkers() or a list for each cluster
 #'   where each element is either a character vector of genes or a list containing a `genes` field.
 #' @param tissue_name Tissue context for the annotation (e.g., 'human PBMC', 'mouse brain')
@@ -262,31 +357,30 @@ create_annotation_prompt <- function(input, tissue_name, top_gene_count = 10) {
 #'   (number of clusters), and `gene_lists` (cluster ID to marker genes mapping).
 #' @export
 create_reasoning_annotation_prompt <- function(input, tissue_name, top_gene_count = 10) {
-  base_prompt <- create_annotation_prompt(input, tissue_name, top_gene_count)
-
-  marker_section <- sub(
-    "\n\nReturn exactly one cell type name per line, in the same order as the clusters shown above, without cluster IDs or explanation\\.$",
-    "",
-    base_prompt$prompt
-  )
+  prompt_data <- prepare_annotation_prompt_data(input, tissue_name, top_gene_count)
 
   reasoning_prompt <- paste0(
-    marker_section,
-    "\n\nFor each cluster, return a JSON object with the following fields:\n",
-    "- \"cluster_id\": the cluster ID as shown above\n",
+    "You are an expert single-cell RNA-seq analyst specializing in cell type annotation.\n",
+    "I need you to identify cell types in ", prompt_data$tissue_name, ".\n",
+    "Below is a list of marker genes for each cluster.\n",
+    "Please assign the most likely cell type to each cluster based on the marker genes.\n\n",
+    "For each cluster, return a JSON object with the following fields:\n",
+    "- \"cluster_id\": the cluster ID as shown below\n",
     "- \"cell_type\": the annotated cell type\n",
     "- \"marker_genes\": the marker genes from the provided gene set that support this annotation, ",
-    "comma-separated, preserving the original case exactly as shown above\n",
+    "comma-separated, preserving the original case exactly as shown below\n",
     "- \"gene_expression\": a concise natural-language description of where each provided ",
     "differential gene is typically expressed across cell types\n\n",
-    "Return a single JSON array containing one object per cluster, in the same order as the clusters shown above. ",
-    "Do not include markdown formatting or any explanation outside the JSON array."
+    "Return a single JSON array containing one object per cluster, in the same order as the clusters shown below. ",
+    "Do not include markdown formatting or any explanation outside the JSON array.\n\n",
+    "Here are the marker genes for each cluster:\n",
+    prompt_data$marker_text
   )
 
   return(list(
     prompt = reasoning_prompt,
-    expected_count = base_prompt$expected_count,
-    gene_lists = base_prompt$gene_lists
+    expected_count = prompt_data$expected_count,
+    gene_lists = prompt_data$gene_lists
   ))
 }
 

--- a/R/man/create_reasoning_annotation_prompt.Rd
+++ b/R/man/create_reasoning_annotation_prompt.Rd
@@ -19,5 +19,10 @@ A list with \code{prompt} (formatted prompt text), \code{expected_count}
 (number of clusters), and \code{gene_lists} (cluster ID to marker genes mapping).
 }
 \description{
-Create reasoning-aware prompt for cell type annotation
+This prompt is built from its own template rather than derived from
+create_annotation_prompt(), so the two prompts can evolve independently.
+The template mirrors REASONING_PROMPT_TEMPLATE in the Python package
+(python/mllmcelltype/prompts.py) so both implementations ask for the same
+structured JSON output; it is adapted to the R signature, which takes a
+single \code{tissue_name} instead of separate species/tissue arguments.
 }

--- a/R/tests/testthat/test-annotate-reasoning.R
+++ b/R/tests/testthat/test-annotate-reasoning.R
@@ -1,5 +1,39 @@
 # Tests for annotate_cell_types return_reasoning functionality
 
+test_that("annotation prompt variants share normalized prompt data", {
+  inputs <- list(
+    list("10" = c(" G10 ", "G10b"), "2" = list(genes = "G2")),
+    data.frame(
+      cluster = c(" 10 ", "2", "10"),
+      gene = c(" G10a ", "G2", "G10b"),
+      avg_log2FC = c(2, 3, 1)
+    )
+  )
+
+  for (input in inputs) {
+    standard <- create_annotation_prompt(input, " PBMC ", top_gene_count = 2)
+    reasoning <- create_reasoning_annotation_prompt(
+      input,
+      " PBMC ",
+      top_gene_count = 2
+    )
+
+    expect_identical(reasoning$expected_count, standard$expected_count)
+    expect_identical(reasoning$gene_lists, standard$gene_lists)
+    expect_identical(names(reasoning$gene_lists), c("2", "10"))
+
+    marker_lines <- paste0(
+      names(standard$gene_lists),
+      ": ",
+      unlist(standard$gene_lists, use.names = FALSE)
+    )
+    for (marker_line in marker_lines) {
+      expect_match(standard$prompt, marker_line, fixed = TRUE)
+      expect_match(reasoning$prompt, marker_line, fixed = TRUE)
+    }
+  }
+})
+
 test_that("annotate_cell_types return_reasoning=TRUE parses JSON array response", {
   json_response <- paste0(
     '[{"cluster_id": "0", "cell_type": "T cells", ',


### PR DESCRIPTION
Address PR review feedback: create_reasoning_annotation_prompt() no longer derives its prompt from create_annotation_prompt() via regex substitution, removing the fragile coupling to the base prompt's trailing instruction. Input normalization is mirrored in an internal prepare_annotation_prompt_data() helper so the reasoning prompt keeps the same canonical cluster ordering without depending on the base prompt's text; create_annotation_prompt() itself is unchanged from upstream.

The reasoning prompt now mirrors Python's REASONING_PROMPT_TEMPLATE so both implementations request the same structured JSON output, adapted to the R signature's single tissue_name argument.

## Description

**What does this PR do?**
<!-- Brief summary of the changes -->

**Why is this change needed?**
<!-- Explain the problem this solves or the value it adds -->

### Related Issues
<!-- Link any related issues -->
- Fixes #
- Related to #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvements
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

<!-- Describe the testing you've done -->
- [ ] All existing tests pass
- [ ] New tests added for changes
- [ ] Tested with real data (if applicable)

**Test Environment:**
- R/Python Version:
- Operating System:

## Checklist

- [ ] Code follows the project's coding standards
- [ ] Self-review of the code completed
- [ ] Documentation updated if needed
- [ ] No API keys or sensitive data exposed
- [ ] I have read and agree to the [Contributing Guidelines](CONTRIBUTING.md)
